### PR TITLE
Proposal: Style tray display to be more in line with GNOME tray icons

### DIFF
--- a/mprisindicatorbutton@tyler.doublejones.com/extension.js
+++ b/mprisindicatorbutton@tyler.doublejones.com/extension.js
@@ -38,7 +38,7 @@ function enable() {
     if (!Panel.statusArea[ROLE]) {
         stockMpris.visible = false;
         stockMpris._shouldShow = () => false;
-        Panel.addToStatusArea(ROLE, new MprisIndicatorButton(), 100, 'left');
+        Panel.addToStatusArea(ROLE, new MprisIndicatorButton());
     }
 }
 

--- a/mprisindicatorbutton@tyler.doublejones.com/stylesheet.css
+++ b/mprisindicatorbutton@tyler.doublejones.com/stylesheet.css
@@ -1,6 +1,6 @@
 .system-status-icon-mpris {
-  height: 1.4em;
-  width: 1.4em;
+  icon-size: 16px;
+  padding-right: 0.4em;
 }
 
 .player-quit-button {


### PR DESCRIPTION
Hi Tyler,

You moved the tray icon to the left. This is a proposal to move it to the right and style the source/provider icon to be more in line with other GNOME tray icons.