### PR TITLE
Add GNOME 38 and 40 support

### DIFF
--- a/mprisindicatorbutton@tyler.doublejones.com/metadata.json
+++ b/mprisindicatorbutton@tyler.doublejones.com/metadata.json
@@ -3,6 +3,6 @@
 "name": "Mpris Indicator Button with title",
 "description": "A full featured MPRIS indicator.",
 "original-author": "JasonLG1979@github.io",
-"shell-version": ["3.36"],
+"shell-version": ["3.36", "3.38", "40.beta", "40"],
 "url": "https://github.com/jylertones/gnome-shell-extension-mpris-indicator-button/"
 }


### PR DESCRIPTION
Based on https://github.com/JasonLG1979/gnome-shell-extension-mpris-indicator-button/pull/57