### PR TITLE
Merge "Add support for GNOME Shell 41" and "Gtk.IconTheme.get_default() can be NULL. Make has_icon call more robust." 

### DIFF
--- a/mprisindicatorbutton@tyler.doublejones.com/dbus.js
+++ b/mprisindicatorbutton@tyler.doublejones.com/dbus.js
@@ -1904,7 +1904,7 @@ const MprisProxyHandler = GObject.registerClass({
 
     _getIcon(symbolic) {
         let iconName = symbolic ? `${this.app_id}-symbolic` : this.app_id;
-        return this.app_id && Gtk.IconTheme.get_default().has_icon(iconName) ? Gio.ThemedIcon.new(iconName) : null;
+        return this.app_id && (Gtk.IconTheme.get_default() ? Gtk.IconTheme.get_default().has_icon(iconName) : false) ? Gio.ThemedIcon.new(iconName) : null;
     }
 
     _getMimeTypeIcon() {

--- a/mprisindicatorbutton@tyler.doublejones.com/metadata.json
+++ b/mprisindicatorbutton@tyler.doublejones.com/metadata.json
@@ -3,6 +3,6 @@
 "name": "Mpris Indicator Button with title",
 "description": "A full featured MPRIS indicator.",
 "original-author": "JasonLG1979@github.io",
-"shell-version": ["3.36", "3.38", "40.beta", "40"],
+"shell-version": ["3.36", "3.38", "40", "41"],
 "url": "https://github.com/jylertones/gnome-shell-extension-mpris-indicator-button/"
 }


### PR DESCRIPTION
Upstream commits:
https://github.com/JasonLG1979/gnome-shell-extension-mpris-indicator-button/commit/11af7e8fed5051b74c6d7fc8ee3506b955547428
https://github.com/JasonLG1979/gnome-shell-extension-mpris-indicator-button/commit/c9dc6e31e6976ef8250676f9d439c9281d9f5004